### PR TITLE
Drop PHP5.6 in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,19 @@ before_install:
 jobs:
   include:
   - stage: lint
-    php: 5.6
+    php: 7.0
+    script:
+    - "./bin/lint.sh"
+  - stage: lint
+    php: 7.1
     script:
     - "./bin/lint.sh"
   - stage: lint
     php: 7.2
+    script:
+    - "./bin/lint.sh"
+  - stage: lint
+    php: 7.3
     script:
     - "./bin/lint.sh"
   - stage: deploy


### PR DESCRIPTION
## Proposed Changes
- Remove PHP 5.6 from Travis build 
- Add missing PHP 7.* versions to Travis

## Linked Issues
- Resolves #162 
