### PR TITLE
Fix WP 5.9 stylesheet name collision

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -38,7 +38,7 @@ transforms.push(postcssBanner({ banner: `
 	Theme Name: Benenson
 	Theme URI: https://benenson.co
 	Description: Named after the founder of the human rights group, Amnesty International, Benenson is an open-source WordPress theme built using Gutenberg
-	Version: 1.1.0
+	Version: 1.1.1
   Requires at least: WordPress 4.9.8
 	Author: Big Bite Creative
 	Author URI: https://bigbitecreative.com

--- a/includes/scripts-and-styles.php
+++ b/includes/scripts-and-styles.php
@@ -36,7 +36,7 @@ function array_reverse_polyfill() {
 		return;
 	}
 
-	wp_enqueue_script( 'benenson-array-reverse', get_theme_file_uri( '/array-reverse-polyfill.js' ), [], '1.1.0', false );
+	wp_enqueue_script( 'benenson-array-reverse', get_theme_file_uri( '/array-reverse-polyfill.js' ), [], '1.1.1', false );
 }
 
 add_action( 'admin_enqueue_scripts', 'array_reverse_polyfill' );
@@ -50,11 +50,11 @@ add_action( 'admin_enqueue_scripts', 'array_reverse_polyfill' );
  */
 if ( ! function_exists( 'benenson_styles' ) ) {
 	function benenson_styles() {
-		wp_enqueue_style( 'theme-styles', get_theme_file_uri( '/style.css' ), [], '1.1.0', 'all' );
-		wp_enqueue_style( 'google-fonts', 'https://fonts.googleapis.com/css?family=Lato:300,400,700|Playfair+Display:400,600,700,700i,900,900i', [], '1.1.0' );
+		wp_enqueue_style( 'theme-styles', get_theme_file_uri( '/style.css' ), [], '1.1.1', 'all' );
+		wp_enqueue_style( 'google-fonts', 'https://fonts.googleapis.com/css?family=Lato:300,400,700|Playfair+Display:400,600,700,700i,900,900i', [], '1.1.1' );
 
 		if ( is_singular( 'post' ) || ! is_page_template( 'templates/without-sidebar' ) ) {
-			wp_enqueue_style( 'print-styles', get_theme_file_uri( '/print.css' ), [], '1.1.0', 'print' );
+			wp_enqueue_style( 'print-styles', get_theme_file_uri( '/print.css' ), [], '1.1.1', 'print' );
 		}
 	}
 }
@@ -63,7 +63,7 @@ add_action( 'wp_enqueue_scripts', 'benenson_styles' );
 
 if ( ! function_exists( 'benenson_editor_styles' ) ) {
 	function benenson_editor_styles() {
-		wp_enqueue_style( 'benenson-blocks-css', get_theme_file_uri( '/style-editor.css' ), [], '1.1.0', 'all' );
+		wp_enqueue_style( 'benenson-blocks-css', get_theme_file_uri( '/style-editor.css' ), [], '1.1.1', 'all' );
 	}
 }
 
@@ -78,7 +78,7 @@ add_action( 'admin_enqueue_scripts', 'benenson_editor_styles' );
  */
 if ( ! function_exists( 'benenson_scripts' ) ) {
 	function benenson_scripts() {
-		wp_enqueue_script( 'global-scripts', get_theme_file_uri( '/bundle.js' ), [], '1.1.0', true );
+		wp_enqueue_script( 'global-scripts', get_theme_file_uri( '/bundle.js' ), [], '1.1.1', true );
 
 		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) && true === apply_filters( 'benenson_comments_enabled', false ) ) {
 			wp_enqueue_script( 'comment-reply' );
@@ -111,11 +111,11 @@ if ( ! function_exists( 'benenson_gutenberg_assets' ) ) {
 			'wp-edit-post',
 			'wp-data',
 			'wp-date',
-		], '1.1.0', false );
+		], '1.1.1', false );
 
 		wp_enqueue_script( 'benenson-blocks-js', get_theme_file_uri( '/blocks.js' ), [
 			'benenson-packages-js',
-		], '1.1.0', false );
+		], '1.1.1', false );
 
 		if ( function_exists( 'gutenberg_get_jed_locale_data' ) ) {
 			// gutenberg plugin

--- a/includes/scripts-and-styles.php
+++ b/includes/scripts-and-styles.php
@@ -50,7 +50,7 @@ add_action( 'admin_enqueue_scripts', 'array_reverse_polyfill' );
  */
 if ( ! function_exists( 'benenson_styles' ) ) {
 	function benenson_styles() {
-		wp_enqueue_style( 'global-styles', get_theme_file_uri( '/style.css' ), [], '1.1.0', 'all' );
+		wp_enqueue_style( 'theme-styles', get_theme_file_uri( '/style.css' ), [], '1.1.0', 'all' );
 		wp_enqueue_style( 'google-fonts', 'https://fonts.googleapis.com/css?family=Lato:300,400,700|Playfair+Display:400,600,700,700i,900,900i', [], '1.1.0' );
 
 		if ( is_singular( 'post' ) || ! is_page_template( 'templates/without-sidebar' ) ) {


### PR DESCRIPTION
## Proposed Changes
- Rename stylesheet handle to avoid collision with WP 5.9's "Global Styles"
- Bump patch version for release
